### PR TITLE
Handle FlightAware destination mismatches when matching departures

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -1106,12 +1106,18 @@ def choose_booking_for_event(subj_info: dict, tails_dashed: list[str], event: st
         if raw_from:
             cand = match_token(cand, "From_IATA", "From_ICAO", raw_from)
         sched_col = "ETA_UTC"
-    
+
     elif event in ("Departure", "EDCT"):
         if raw_from:
             cand = match_token(cand, "From_IATA", "From_ICAO", raw_from)
         if raw_to:
-            cand = match_token(cand, "To_IATA", "To_ICAO", raw_to)
+            # Only constrain on the destination if it actually matches something.
+            # This allows us to still match the scheduled leg when FlightAware emails
+            # mention a different arrival airport (which we flag separately as a
+            # route mismatch alert).
+            cand_to = match_token(cand, "To_IATA", "To_ICAO", raw_to)
+            if not cand_to.empty:
+                cand = cand_to
         sched_col = "ETD_UTC"
     
     elif event == "Diversion":


### PR DESCRIPTION
## Summary
- fall back to matching departure and EDCT emails on the origin airport when the destination token from FlightAware does not match
- preserve the existing route mismatch alert while ensuring the leg still receives the departure status

## Testing
- python -m compileall 'ASP FF Dashboard.py'

------
https://chatgpt.com/codex/tasks/task_e_68d40566e5008333b3151aee5115c586