### PR TITLE
Restore interactive schedule table with tail links

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -2277,7 +2277,9 @@ else:
 
 try:
     styler = styler.apply(_style_ops, axis=None).format(fmt_map)
-    st.markdown(styler.to_html(), unsafe_allow_html=True)
+    if "Aircraft" in df_display.columns:
+        styler = styler.format(escape=False, subset=["Aircraft"])
+    st.dataframe(styler, use_container_width=True)
 except Exception:
     st.warning("Styling disabled (env compatibility). Showing plain table.")
     tmp = df_display.copy()


### PR DESCRIPTION
## Summary
- restore the schedule renderer to use `st.dataframe` so the grid regains resizing, search, and scrolling controls
- keep FlightAware tail links clickable by disabling HTML escaping on the Aircraft column when styling

## Testing
- python -m compileall 'ASP FF Dashboard.py'

------
https://chatgpt.com/codex/tasks/task_e_68d54c521d7c83338aad04e6972e4f5e