### PR TITLE
Support custom FL3XX auth header names

### DIFF
--- a/fl3xx_client.py
+++ b/fl3xx_client.py
@@ -21,6 +21,7 @@ class Fl3xxApiConfig:
     base_url: str = DEFAULT_FL3XX_BASE_URL
     api_token: Optional[str] = None
     auth_header: Optional[str] = None
+    auth_header_name: str = "Authorization"
     extra_headers: Dict[str, str] = field(default_factory=dict)
     verify_ssl: bool = True
     timeout: int = 30
@@ -29,7 +30,8 @@ class Fl3xxApiConfig:
     def build_headers(self) -> Dict[str, str]:
         headers = {"Accept": "application/json"}
         if self.auth_header:
-            headers["Authorization"] = self.auth_header
+            header_name = self.auth_header_name or "Authorization"
+            headers[header_name] = self.auth_header
         elif self.api_token:
             headers["Authorization"] = f"Bearer {self.api_token}"
         headers.update(self.extra_headers)

--- a/tests/test_dashboard_config.py
+++ b/tests/test_dashboard_config.py
@@ -71,3 +71,22 @@ def test_build_config_accepts_mapping(monkeypatch):
 
     assert config.api_token == "token-123"
     assert config.auth_header == "Bearer abc"
+
+
+def test_build_config_allows_custom_auth_header_name(monkeypatch):
+    secrets_mapping = {
+        "fl3xx_api": {
+            "auth_header": "Token abc123",
+            "auth_header_name": "X-Auth-Token",
+        }
+    }
+
+    monkeypatch.setattr(st, "secrets", secrets_mapping, raising=False)
+
+    config = _build_fl3xx_config_from_secrets()
+
+    assert config.auth_header == "Token abc123"
+    assert config.auth_header_name == "X-Auth-Token"
+    headers = config.build_headers()
+    assert headers["X-Auth-Token"] == "Token abc123"
+    assert "Authorization" not in headers or headers["Authorization"] != "Token abc123"

--- a/tests/test_fl3xx_client.py
+++ b/tests/test_fl3xx_client.py
@@ -73,6 +73,15 @@ def test_fetch_flights_builds_expected_request_parameters():
     assert call["verify"] == config.verify_ssl
 
 
+def test_build_headers_supports_custom_auth_header_name():
+    config = Fl3xxApiConfig(auth_header="Token abc123", auth_header_name="X-Auth-Token")
+
+    headers = config.build_headers()
+
+    assert headers["X-Auth-Token"] == "Token abc123"
+    assert "Authorization" not in headers or headers["Authorization"] != "Token abc123"
+
+
 def test_fetch_flights_accepts_payload_wrapped_in_items_list():
     payload = {"items": [{"bookingIdentifier": "ABC"}]}
     response = FakeResponse(payload)


### PR DESCRIPTION
## Summary
- add an auth_header_name option to `Fl3xxApiConfig` so custom authorization headers can be emitted
- load `auth_header_name` from Streamlit secrets or environment variables when building the dashboard configuration and refresh the user guidance
- extend the unit tests to cover custom header names for both the dashboard config helper and the FL3XX client

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dea7aeae98833394bd70314e2df0b3