### PR TITLE
Allow configuring FL3XX token scheme

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -293,6 +293,18 @@ def _build_fl3xx_config_from_secrets() -> Fl3xxApiConfig:
     else:
         auth_header_name = "Authorization"
 
+    token_scheme_value = (
+        merged.get("api_token_scheme")
+        or merged.get("token_scheme")
+        or merged.get("token_type")
+        or st.secrets.get("FL3XX_API_TOKEN_SCHEME")
+        or os.getenv("FL3XX_API_TOKEN_SCHEME")
+    )
+    if token_scheme_value is None:
+        api_token_scheme = "Bearer"
+    else:
+        api_token_scheme = str(token_scheme_value)
+
     headers = merged.get("headers")
     extra_headers = dict(headers) if isinstance(headers, Mapping) else {}
 
@@ -318,6 +330,7 @@ def _build_fl3xx_config_from_secrets() -> Fl3xxApiConfig:
         api_token=api_token,
         auth_header=auth_header,
         auth_header_name=auth_header_name,
+        api_token_scheme=api_token_scheme,
         extra_headers=extra_headers,
         verify_ssl=verify_ssl,
         timeout=timeout,

--- a/fl3xx_client.py
+++ b/fl3xx_client.py
@@ -22,6 +22,7 @@ class Fl3xxApiConfig:
     api_token: Optional[str] = None
     auth_header: Optional[str] = None
     auth_header_name: str = "Authorization"
+    api_token_scheme: Optional[str] = "Bearer"
     extra_headers: Dict[str, str] = field(default_factory=dict)
     verify_ssl: bool = True
     timeout: int = 30
@@ -29,11 +30,13 @@ class Fl3xxApiConfig:
 
     def build_headers(self) -> Dict[str, str]:
         headers = {"Accept": "application/json"}
+        header_name = self.auth_header_name or "Authorization"
         if self.auth_header:
-            header_name = self.auth_header_name or "Authorization"
             headers[header_name] = self.auth_header
         elif self.api_token:
-            headers["Authorization"] = f"Bearer {self.api_token}"
+            scheme = (self.api_token_scheme or "").strip()
+            token = str(self.api_token)
+            headers[header_name] = f"{scheme} {token}".strip() if scheme else token
         headers.update(self.extra_headers)
         return headers
 

--- a/tests/test_dashboard_config.py
+++ b/tests/test_dashboard_config.py
@@ -90,3 +90,22 @@ def test_build_config_allows_custom_auth_header_name(monkeypatch):
     headers = config.build_headers()
     assert headers["X-Auth-Token"] == "Token abc123"
     assert "Authorization" not in headers or headers["Authorization"] != "Token abc123"
+
+
+def test_build_config_allows_custom_token_scheme(monkeypatch):
+    secrets_mapping = {
+        "fl3xx_api": {
+            "api_token": "abc123",
+            "api_token_scheme": "Token",
+            "auth_header_name": "X-Auth-Token",
+        }
+    }
+
+    monkeypatch.setattr(st, "secrets", secrets_mapping, raising=False)
+
+    config = _build_fl3xx_config_from_secrets()
+
+    assert config.api_token == "abc123"
+    assert config.api_token_scheme == "Token"
+    headers = config.build_headers()
+    assert headers["X-Auth-Token"] == "Token abc123"

--- a/tests/test_fl3xx_client.py
+++ b/tests/test_fl3xx_client.py
@@ -82,6 +82,26 @@ def test_build_headers_supports_custom_auth_header_name():
     assert "Authorization" not in headers or headers["Authorization"] != "Token abc123"
 
 
+def test_build_headers_supports_custom_token_scheme_and_header_name():
+    config = Fl3xxApiConfig(
+        api_token="abc123",
+        auth_header_name="X-Auth-Token",
+        api_token_scheme="Token",
+    )
+
+    headers = config.build_headers()
+
+    assert headers["X-Auth-Token"] == "Token abc123"
+
+
+def test_build_headers_allows_empty_token_scheme():
+    config = Fl3xxApiConfig(api_token="abc123", api_token_scheme="")
+
+    headers = config.build_headers()
+
+    assert headers["Authorization"] == "abc123"
+
+
 def test_fetch_flights_accepts_payload_wrapped_in_items_list():
     payload = {"items": [{"bookingIdentifier": "ABC"}]}
     response = FakeResponse(payload)


### PR DESCRIPTION
## Summary
- allow overriding the authentication scheme used for FL3XX API tokens
- expose the new option through the Streamlit secrets helper
- expand automated tests to cover the new configuration behaviours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68deaa59260c8333a1aa441f4c829306