### PR TITLE
Default to raw token when using custom FL3XX auth header names

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -301,7 +301,10 @@ def _build_fl3xx_config_from_secrets() -> Fl3xxApiConfig:
         or os.getenv("FL3XX_API_TOKEN_SCHEME")
     )
     if token_scheme_value is None:
-        api_token_scheme = "Bearer"
+        if auth_header_name.lower() == "authorization":
+            api_token_scheme = "Bearer"
+        else:
+            api_token_scheme = ""
     else:
         api_token_scheme = str(token_scheme_value)
 

--- a/fl3xx_client.py
+++ b/fl3xx_client.py
@@ -22,7 +22,7 @@ class Fl3xxApiConfig:
     api_token: Optional[str] = None
     auth_header: Optional[str] = None
     auth_header_name: str = "Authorization"
-    api_token_scheme: Optional[str] = "Bearer"
+    api_token_scheme: Optional[str] = None
     extra_headers: Dict[str, str] = field(default_factory=dict)
     verify_ssl: bool = True
     timeout: int = 30
@@ -34,8 +34,12 @@ class Fl3xxApiConfig:
         if self.auth_header:
             headers[header_name] = self.auth_header
         elif self.api_token:
-            scheme = (self.api_token_scheme or "").strip()
             token = str(self.api_token)
+            scheme = self.api_token_scheme
+            if scheme is None:
+                scheme = "Bearer" if header_name.lower() == "authorization" else ""
+            else:
+                scheme = scheme.strip()
             headers[header_name] = f"{scheme} {token}".strip() if scheme else token
         headers.update(self.extra_headers)
         return headers

--- a/tests/test_fl3xx_client.py
+++ b/tests/test_fl3xx_client.py
@@ -102,6 +102,14 @@ def test_build_headers_allows_empty_token_scheme():
     assert headers["Authorization"] == "abc123"
 
 
+def test_build_headers_defaults_to_raw_token_for_custom_header_name():
+    config = Fl3xxApiConfig(api_token="abc123", auth_header_name="X-Auth-Token")
+
+    headers = config.build_headers()
+
+    assert headers["X-Auth-Token"] == "abc123"
+
+
 def test_fetch_flights_accepts_payload_wrapped_in_items_list():
     payload = {"items": [{"bookingIdentifier": "ABC"}]}
     response = FakeResponse(payload)


### PR DESCRIPTION
## Summary
- update the FL3XX client headers to infer a default token scheme from the header name
- avoid adding the Bearer prefix when building configuration with custom auth header names
- cover the new behaviour with a regression test for the custom header default

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68deabcb91dc83338ffc59980a863aa2