### PR TITLE
Add FlightAware webhook ingestion via DynamoDB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tzlocal
 timezonefinder
 requests
 pytest
+boto3


### PR DESCRIPTION
## Summary
- add optional DynamoDB webhook configuration and fetch helpers for FlightAware OOOI events
- map ASP callsigns to tails to derive ident lookups and apply webhook updates to the in-app status map
- expose a Streamlit toggle for webhook ingestion and add boto3 to the requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e47c9aaa2483339b3d46a384f6945c