### PR TITLE
Add diagnostics for Streamlit secrets

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -43,6 +43,31 @@ from flightaware_status import (
     fetch_flights_for_ident,
 )
 
+
+def _show_secrets_shape() -> None:
+    """Display which Streamlit secrets are available without revealing values."""
+
+    st.write("Top-level st.secrets keys:", list(st.secrets.keys()))
+
+    check: dict[str, str] = {}
+    for key in [
+        "AWS_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "FLIGHTAWARE_ALERTS_TABLE",
+    ]:
+        value = st.secrets.get(key)
+        check[key] = "present" if isinstance(value, str) and value.strip() else "missing/empty"
+
+    st.write("Presence check:", check)
+
+    for section in ["aws", "AWS", "flightaware", "secrets"]:
+        if section in st.secrets:
+            st.write(f"Found nested section [{section}] with keys:", list(st.secrets[section].keys()))
+
+
+_show_secrets_shape()
+
 # Global lookup maps populated after loading airport metadata. Define them early so
 # helper functions can reference the names during the initial Streamlit run.
 ICAO_TZ_MAP: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- add a helper function that reports which Streamlit secrets are available without exposing values
- surface the presence of common AWS- and FlightAware-related keys to simplify debugging
- list any nested secret sections that might hold credentials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e544ceca508333a5fb9338d9368b77