### PR TITLE
Handle non-ICAO airport codes in schedule display

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -1824,12 +1824,23 @@ def derive_iata_from_icao(icao: str) -> str:
     return ""
 
 def display_airport(icao: str, iata: str) -> str:
+    """Return the best airport token available for display."""
+
     i = (icao or "").strip().upper()
     a = (iata or "").strip().upper()
-    if i and len(i) == 4:
+
+    # Prefer the "ICAO" value when provided, even if it is not a
+    # four-character identifier. Some FL3XX API responses supply an IATA
+    # identifier (or another local code such as an FAA/TC identifier) in this
+    # field when no ICAO exists. Showing that token avoids a blank schedule
+    # entry and allows downstream FlightAware matching logic to work with the
+    # displayed value.
+    if i:
         return i
-    if a and len(a) == 3:
+
+    if a:
         return a
+
     return "—"
 
 

--- a/tests/test_schedule_display.py
+++ b/tests/test_schedule_display.py
@@ -1,0 +1,45 @@
+import ast
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "ASP FF Dashboard.py"
+
+
+with MODULE_PATH.open("r", encoding="utf-8") as fp:
+    MODULE_SOURCE = fp.read()
+
+MODULE_AST = ast.parse(MODULE_SOURCE, filename=str(MODULE_PATH))
+
+_TARGET_NAME = "display_airport"
+_TARGET_SOURCE = None
+
+for node in MODULE_AST.body:
+    if isinstance(node, ast.FunctionDef) and node.name == _TARGET_NAME:
+        _TARGET_SOURCE = ast.get_source_segment(MODULE_SOURCE, node)
+        break
+
+if _TARGET_SOURCE is None:  # pragma: no cover - safety guard for refactors
+    raise RuntimeError(f"{_TARGET_NAME} not found in dashboard module")
+
+
+namespace: dict[str, object] = {}
+exec(_TARGET_SOURCE, namespace)
+
+display_airport = namespace[_TARGET_NAME]
+
+
+def test_display_airport_prefers_icao_token_when_available():
+    assert display_airport("CYEG", "YEG") == "CYEG"
+
+
+def test_display_airport_preserves_non_icao_identifiers():
+    # Some airports only supply a three-character identifier (e.g. IATA).
+    assert display_airport("YJP", "") == "YJP"
+
+
+def test_display_airport_falls_back_to_iata_when_icao_missing():
+    assert display_airport("", "YJP") == "YJP"
+
+
+def test_display_airport_returns_placeholder_when_no_tokens():
+    assert display_airport("", "") == "—"


### PR DESCRIPTION
## Summary
- ensure the schedule renders whichever airport identifier is supplied, even when the FL3XX payload lacks a four-character ICAO code
- add regression tests for display_airport covering ICAO, IATA, and fallback behaviours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e563f2885483339ff8bdd7590ca073