### PR TITLE
Use FlightAware ETA for arrival countdown

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -3117,6 +3117,14 @@ df["_ETA_FA_ts"]    = pd.to_datetime(eta_fore_list,   utc=True)
 df["_ArrActual_ts"] = pd.to_datetime(arr_actual_list, utc=True)
 df["_EDCT_ts"]      = pd.to_datetime(edct_list,       utc=True)
 
+if not df.empty:
+    eta_fa_series = df["_ETA_FA_ts"]
+    mask_eta_fa = eta_fa_series.notna()
+    if mask_eta_fa.any():
+        df.loc[mask_eta_fa, "Arrives In"] = (
+            (eta_fa_series[mask_eta_fa] - now_utc).apply(fmt_td)
+        )
+
 df["_RouteMismatch"] = route_mismatch_flags
 df["_RouteMismatchMsg"] = route_mismatch_msgs
 for idx in df.index[df["_RouteMismatch"]]:


### PR DESCRIPTION
## Summary
- update the Arrives In countdown to use FlightAware ETA data when available for more accurate timings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e679737f808333860ed65965f70a8e