### PR TITLE
Ensure Arrives In countdown honors FlightAware ETA

### DIFF
--- a/ASP FF Dashboard.py
+++ b/ASP FF Dashboard.py
@@ -3117,6 +3117,12 @@ df["_ETA_FA_ts"]    = pd.to_datetime(eta_fore_list,   utc=True)
 df["_ArrActual_ts"] = pd.to_datetime(arr_actual_list, utc=True)
 df["_EDCT_ts"]      = pd.to_datetime(edct_list,       utc=True)
 
+if not df.empty:
+    eta_fa_series = df["_ETA_FA_ts"]
+    eta_countdown_source = eta_fa_series.combine_first(df["ETA_UTC"])
+    countdown_now = pd.Timestamp.now(tz=timezone.utc)
+    df["Arrives In"] = (eta_countdown_source - countdown_now).apply(fmt_td)
+
 df["_RouteMismatch"] = route_mismatch_flags
 df["_RouteMismatchMsg"] = route_mismatch_msgs
 for idx in df.index[df["_RouteMismatch"]]:


### PR DESCRIPTION
## Summary
- recompute the Arrives In countdown using the FlightAware ETA when available and fall back to the scheduled arrival when it is not

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e679737f808333860ed65965f70a8e